### PR TITLE
Revert "kuntao: Drop deprecated OpenGLRenderer props"

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -19,6 +19,7 @@ DEVICE_PACKAGE_OVERLAYS += $(LOCAL_PATH)/overlay
 PRODUCT_AAPT_CONFIG := normal
 PRODUCT_AAPT_PREF_CONFIG := xxhdpi
 
+$(call inherit-product, frameworks/native/build/phone-xxhdpi-3072-hwui-memory.mk)
 $(call inherit-product, frameworks/native/build/phone-xxhdpi-3072-dalvik-heap.mk)
 
 # Permissions


### PR DESCRIPTION
This reverts commit @https://github.com/AospExtended-Devices/device_lenovo_kuntao/commit/e18ed5704a11d356bd679e5462e8f0f7081bbd26

* Battery drain problems