### PR TITLE
Revert "kuntao: add custom, tested flinger velocities"

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -154,8 +154,3 @@ persist.radio.aosp_usr_pref_sel=true
 
 # WiFi
 wifi.interface=wlan0
-
-# Higher fling velocities to smooth scrolling
-# and provide better responsiveness
-ro.min.fling_velocity=160
-ro.max.fling_velocity=20000


### PR DESCRIPTION
* This reverts commit @https://github.com/AospExtended-Devices/device_lenovo_kuntao/commit/dcb28a01843276518e5bb7ec6aa15aeab123001f

* Battery drain problems